### PR TITLE
Модуль авторизации через VK ID

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -35,6 +35,15 @@
         "revision" : "cee3c709307912d040bd1e06ca919875a92339c6",
         "version" : "2.0.0"
       }
+    },
+    {
+      "identity" : "vksdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/VKCOM/VKSDK-iOS",
+      "state" : {
+        "branch" : "0.101.0",
+        "revision" : "bd6789232a6282ec50ce80571553f7ad973a765c"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -12,14 +12,15 @@ let package = Package(
         .library(name: "ThirdPartyAuthUI", targets: ["ThirdPartyAuthUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/google/GoogleSignIn-iOS", revision: "7.0.0")
+        .package(url: "https://github.com/google/GoogleSignIn-iOS", revision: "7.0.0"),
+        .package(url: "https://github.com/VKCOM/VKSDK-iOS", revision: "0.101.0")
     ],
     targets: [
         .target(
             name: "ThirdPartyAuth",
             dependencies: [
-                .product(name: "GoogleSignIn",
-                         package: "GoogleSignIn-iOS")
+                .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),
+                .product(name: "VK", package: "VKSDK-iOS")
             ]
         ),
         .target(name: "ThirdPartyAuthUI", dependencies: ["ThirdPartyAuth"]),

--- a/Sources/ThirdPartyAuth/Flows/Apple/AppleAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/Apple/AppleAuthProvider.swift
@@ -44,8 +44,6 @@ final class AppleAuthProvider: NSObject, BaseAuthProvider {
         authorizationController.performRequests()
     }
 
-    func signOut() {}
-
 }
 
 // MARK: - ASAuthorizationControllerDelegate

--- a/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthProvider.swift
@@ -98,7 +98,16 @@ private extension GoogleAuthProvider {
         }
 
         let userModel = ThirdPartyAuthUserModel(from: user)
-        onAuthFinished?(.success(userModel))
+
+        /// Try to dismiss Google Sign-In screen (at this moment it's on top)
+        guard let signInViewController = UIApplication.topViewController() else {
+            onAuthFinished?(.success(userModel))
+            return
+        }
+
+        signInViewController.dismiss(animated: true) { [weak self] in
+            self?.onAuthFinished?(.success(userModel))
+        }
     }
 
 }

--- a/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import GoogleSignIn
 
 /// Google sign in authorization process provider
-final class GoogleAuthProvider: NSObject, BaseAuthProvider {
+final class GoogleAuthProvider: BaseAuthProvider {
 
     // MARK: - Nested Types
 

--- a/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthUserModel.swift
+++ b/Sources/ThirdPartyAuth/Flows/Google/GoogleAuthUserModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import GoogleSignIn
 
-/// User data model, returned by Sing in with Apple authorization provider
+/// User data model, returned by Google Sign-In authorization provider
 public struct GoogleAuthUserModel: UserDataModel {
 
     // MARK: - Public Properties

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthConfiguration.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthConfiguration.swift
@@ -10,7 +10,9 @@ public struct VKAuthConfiguration {
 
     // MARK: - Public Properties
 
+    /// App ID of your app at VK developers platform
     let clientId: String
+    /// Secure key of your app at VK developers platform
     let clientSecret: String
 
     // MARK: - Initialization

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthConfiguration.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthConfiguration.swift
@@ -1,0 +1,23 @@
+//
+//  VKAuthConfiguration.swift
+//  ThirdPartyAuth
+//
+//  Created by Ilya Klimenyuk on 14.05.2023.
+//
+
+/// VK ID authorization provider's configuration
+public struct VKAuthConfiguration {
+
+    // MARK: - Public Properties
+
+    let clientId: String
+    let clientSecret: String
+
+    // MARK: - Initialization
+
+    public init(clientId: String, clientSecret: String) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+    }
+
+}

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
@@ -1,0 +1,130 @@
+//
+//  VKAuthProvider.swift
+//  ThirdPartyAuth
+//
+//  Created by Ilya Klimenyuk on 14.05.2023.
+//
+
+import VKSDK
+import UIKit
+
+/// VK ID authorization process provider
+final class VKAuthProvider: NSObject, BaseAuthProvider {
+
+    // MARK: - Nested Types
+
+    enum VKAuthError: Error {
+        case authControllerPresentationProblem
+        case noVKIDAccessTokenProvided
+        case unsupportedAuthSessionState
+        case userIsAlreadyAuthenticated
+    }
+
+    // MARK: - Properties
+
+    var onAuthFinished: ((ThirdPartyAuthResult) -> Void)?
+
+    // MARK: - Private Properties
+
+    private(set) var sharedVK: VK.Type2<App, VKID>?
+
+    // MARK: - Methods
+
+    func start(with configuration: VKAuthConfiguration?) {
+        guard
+            let configuration = configuration,
+            !configuration.clientId.isEmpty,
+            !configuration.clientSecret.isEmpty
+        else {
+            return
+        }
+
+        configureVKAuthInstance(with: configuration)
+    }
+
+    func canHandle(_ url: URL) -> Bool {
+        (try? sharedVK?.open(url: url)) ?? false
+    }
+
+    func signIn() {
+        guard
+            let vk = sharedVK,
+            let topViewController = UIApplication.topViewController()
+        else {
+            onAuthFinished?(.failure(VKAuthError.authControllerPresentationProblem))
+            return
+        }
+
+        do {
+            let authController = getAuthControllerForOauthCodeFlow()
+            let controller = try vk.vkid.ui(for: authController).uiViewController()
+
+            topViewController.present(controller, animated: true)
+        } catch {
+            debugPrint("Couldn't create VK AuthController, error: \(error)")
+            onAuthFinished?(.failure(VKAuthError.authControllerPresentationProblem))
+        }
+    }
+
+    func signOut() {
+        let vkid = sharedVK?.vkid
+        vkid?.userSessions.first?.authorized?.logout { result in
+            debugPrint("User session logged out with result: \(result)")
+        }
+    }
+
+}
+
+// MARK: - VKIDFlowDelegate
+
+extension VKAuthProvider: VKIDFlowDelegate {
+
+    func vkid(_ vkid: VKSDK.VKID.Module, didCompleteAuthWith result: Result<VKSDK.VKID.UserSession, Error>) {
+        do {
+            let session = try result.get()
+
+            switch session.state {
+            case .authenticated:
+                onAuthFinished?(.failure(VKAuthError.userIsAlreadyAuthenticated))
+            case .authorized(let authorized):
+                guard let accessToken = authorized.accessToken else {
+                    onAuthFinished?(.failure(VKAuthError.noVKIDAccessTokenProvided))
+                    return
+                }
+
+                let userModel = ThirdPartyAuthUserModel(from: accessToken)
+                onAuthFinished?(.success(userModel))
+            @unknown default:
+                onAuthFinished?(.failure(VKAuthError.unsupportedAuthSessionState))
+            }
+
+        } catch {
+            onAuthFinished?(.failure(error))
+        }
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension VKAuthProvider {
+
+    func configureVKAuthInstance(with configuration: VKAuthConfiguration) {
+        do {
+            sharedVK = try VK {
+                App(credentials: .init(clientId: configuration.clientId, clientSecret: configuration.clientSecret))
+                VKID()
+            }
+        } catch {
+            debugPrint("Couldn't initialize VKSDK, error: \(error)")
+        }
+    }
+
+    func getAuthControllerForOauthCodeFlow() -> VKID.AuthController {
+        VKID.AuthController(
+            flow: .externalCodeFlow(),
+            delegate: self
+        )
+    }
+
+}

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
@@ -24,7 +24,7 @@ final class VKAuthProvider: NSObject, BaseAuthProvider {
 
     // MARK: - Private Properties
 
-    private(set) var sharedVK: VK.Type2<App, VKID>?
+    private var sharedVK: VK.Type2<App, VKID>?
 
     // MARK: - Methods
 

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
@@ -57,7 +57,9 @@ final class VKAuthProvider: NSObject, BaseAuthProvider {
 
         do {
             let authController = getAuthControllerForOauthCodeFlow()
-            let controller = try vk.vkid.ui(for: authController).uiViewController()
+            //let controller = try vk.vkid.ui(for: authController).uiViewController()
+            let controller = try vk.vkid.ui(for: authController).uiViewController(configuration: .default)
+            controller.modalPresentationStyle = .overFullScreen
 
             topViewController.present(controller, animated: true)
         } catch {

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthProvider.swift
@@ -86,7 +86,16 @@ extension VKAuthProvider: VKIDFlowDelegate {
             }
 
             let userModel = ThirdPartyAuthUserModel(from: accessToken)
-            onAuthFinished?(.success(userModel))
+
+            /// Try to dismiss root VK ID auth controller
+            guard let signInViewController = UIApplication.topViewController()?.presentingViewController else {
+                onAuthFinished?(.success(userModel))
+                return
+            }
+
+            signInViewController.dismiss(animated: true) { [weak self] in
+                self?.onAuthFinished?(.success(userModel))
+            }
 
         } catch {
             onAuthFinished?(.failure(error))

--- a/Sources/ThirdPartyAuth/Flows/VK/VKAuthUserModel.swift
+++ b/Sources/ThirdPartyAuth/Flows/VK/VKAuthUserModel.swift
@@ -1,0 +1,24 @@
+//
+//  VKAuthUserModel.swift
+//  ThirdPartyAuth
+//
+//  Created by Ilya Klimenyuk on 14.05.2023.
+//
+
+import Foundation
+import VK
+
+/// User data model, returned by VK ID authorization provider
+public struct VKAuthUserModel: UserDataModel {
+
+    // MARK: - Public Properties
+
+    public let accessToken: VKID.AccessToken
+
+    // MARK: - Initialization
+
+    public init(accessToken: VKID.AccessToken) {
+        self.accessToken = accessToken
+    }
+
+}

--- a/Sources/ThirdPartyAuth/Library/Models/ThirdPartyAuthServiceConfiguration.swift
+++ b/Sources/ThirdPartyAuth/Library/Models/ThirdPartyAuthServiceConfiguration.swift
@@ -13,12 +13,16 @@ public struct ThirdPartyAuthServiceConfiguration {
 
     let authTypes: [ThirdPartyAuthType]
     let googleClientID: String?
+    let vkAuthConfiguration: VKAuthConfiguration?
 
     // MARK: - Initialization
 
-    public init(authTypes: [ThirdPartyAuthType], googleClientID: String? = nil) {
+    public init(authTypes: [ThirdPartyAuthType],
+                googleClientID: String? = nil,
+                vkAuthConfiguration: VKAuthConfiguration? = nil) {
         self.authTypes = authTypes
         self.googleClientID = googleClientID
+        self.vkAuthConfiguration = vkAuthConfiguration
     }
 
 }

--- a/Sources/ThirdPartyAuth/Library/Models/ThirdPartyAuthUserModel.swift
+++ b/Sources/ThirdPartyAuth/Library/Models/ThirdPartyAuthUserModel.swift
@@ -7,6 +7,7 @@
 
 import AuthenticationServices
 import GoogleSignIn
+import VK
 
 /// Common user data model, returned by third party authorization service
 public struct ThirdPartyAuthUserModel {
@@ -28,6 +29,11 @@ public struct ThirdPartyAuthUserModel {
     init(from googleUser: GIDGoogleUser) {
         self.authType = .google
         self.userData = GoogleAuthUserModel(idToken: googleUser.idToken)
+    }
+
+    init(from vkIDAccessToken: VKID.AccessToken) {
+        self.authType = .vk
+        self.userData = VKAuthUserModel(accessToken: vkIDAccessToken)
     }
 
 }

--- a/Sources/ThirdPartyAuth/Library/Protocols/BaseAuthProvider.swift
+++ b/Sources/ThirdPartyAuth/Library/Protocols/BaseAuthProvider.swift
@@ -14,5 +14,11 @@ protocol BaseAuthProvider {
     /// Common method for signIn user by third party services
     func signIn()
     /// Common method for signOut user by third party services
-    func signOut()
+    func signOut(_ onSignOutComplete: ((Bool) -> Void)?)
+}
+
+extension BaseAuthProvider {
+
+    func signOut(_ onSignOutComplete: ((Bool) -> Void)?) {}
+
 }

--- a/Sources/ThirdPartyAuth/Services/Auth/ThirdPartyAuthServiceInterface.swift
+++ b/Sources/ThirdPartyAuth/Services/Auth/ThirdPartyAuthServiceInterface.swift
@@ -26,5 +26,5 @@ public protocol ThirdPartyAuthServiceInterface: AnyObject {
     /// Sign in with third party auth provider
     func signIn(with authType: ThirdPartyAuthType)
     /// Sign out with third party auth provider (not used for Sign In with Apple)
-    func signOut(with authType: ThirdPartyAuthType)
+    func signOut(with authType: ThirdPartyAuthType, _ onSignOutComplete: ((Bool) -> Void)?)
 }

--- a/Sources/ThirdPartyAuth/Services/Auth/ThirdPartyAuthServiceInterface.swift
+++ b/Sources/ThirdPartyAuth/Services/Auth/ThirdPartyAuthServiceInterface.swift
@@ -17,6 +17,8 @@ public protocol ThirdPartyAuthServiceInterface: AnyObject {
     func start(with configuration: ThirdPartyAuthServiceConfiguration)
     /// Check is any of supported third party auth providers can handle given url
     func canHandle(_ url: URL) -> Bool
+    /// Handle universal links for seamless auth (used only for VK ID Auth)
+    func canContinue(userActivity: NSUserActivity) -> Bool
     /// Check is user with given id authorized (used only for Sign In with Apple)
     func checkCredentialsState(for userID: String, _ onCheckCredentialsValid: @escaping (Bool) -> Void)
     /// Try to restore user's previous sign in (used only for Google Sign-In)

--- a/ThirdPartyAuth.xcodeproj/project.pbxproj
+++ b/ThirdPartyAuth.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		B285D5E329F2CFF300B86937 /* ThirdPartyAuthUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B285D5E229F2CFF300B86937 /* ThirdPartyAuthUserModel.swift */; };
 		B285D5E929F2D02600B86937 /* BaseAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B285D5E829F2D02600B86937 /* BaseAuthProvider.swift */; };
 		B2C83D6829FD900900301FE9 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = B2C83D6729FD900900301FE9 /* GoogleSignIn */; };
+		B2DB4EAA2A0E1B8500246CE8 /* VK in Frameworks */ = {isa = PBXBuildFile; productRef = B2DB4EA92A0E1B8500246CE8 /* VK */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2C83D6829FD900900301FE9 /* GoogleSignIn in Frameworks */,
+				B2DB4EAA2A0E1B8500246CE8 /* VK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,6 +449,7 @@
 			name = ThirdPartyAuth;
 			packageProductDependencies = (
 				B2C83D6729FD900900301FE9 /* GoogleSignIn */,
+				B2DB4EA92A0E1B8500246CE8 /* VK */,
 			);
 			productName = ThirdPartyAuth;
 			productReference = B285D5BA29F2CE7D00B86937 /* ThirdPartyAuth.framework */;
@@ -507,6 +510,7 @@
 			mainGroup = B285D5B029F2CE7D00B86937;
 			packageReferences = (
 				B2C83D6629FD900900301FE9 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+				B2DB4EA82A0E1B8500246CE8 /* XCRemoteSwiftPackageReference "VKSDK-iOS" */,
 			);
 			productRefGroup = B285D5BB29F2CE7D00B86937 /* Products */;
 			projectDirPath = "";
@@ -1091,6 +1095,14 @@
 				version = 7.0.0;
 			};
 		};
+		B2DB4EA82A0E1B8500246CE8 /* XCRemoteSwiftPackageReference "VKSDK-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/VKCOM/VKSDK-iOS";
+			requirement = {
+				kind = exactVersion;
+				version = 0.101.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1098,6 +1110,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B2C83D6629FD900900301FE9 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignIn;
+		};
+		B2DB4EA92A0E1B8500246CE8 /* VK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B2DB4EA82A0E1B8500246CE8 /* XCRemoteSwiftPackageReference "VKSDK-iOS" */;
+			productName = VK;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ThirdPartyAuth.xcodeproj/project.pbxproj
+++ b/ThirdPartyAuth.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		B285D5E329F2CFF300B86937 /* ThirdPartyAuthUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B285D5E229F2CFF300B86937 /* ThirdPartyAuthUserModel.swift */; };
 		B285D5E929F2D02600B86937 /* BaseAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B285D5E829F2D02600B86937 /* BaseAuthProvider.swift */; };
 		B2C83D6829FD900900301FE9 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = B2C83D6729FD900900301FE9 /* GoogleSignIn */; };
+		B2CE71C12A10C509006C42AB /* VKAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CE71C02A10C509006C42AB /* VKAuthProvider.swift */; };
+		B2CE71C32A10C5C6006C42AB /* VKAuthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CE71C22A10C5C6006C42AB /* VKAuthConfiguration.swift */; };
+		B2CE71C52A10E704006C42AB /* VKAuthUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CE71C42A10E704006C42AB /* VKAuthUserModel.swift */; };
 		B2DB4EAA2A0E1B8500246CE8 /* VK in Frameworks */ = {isa = PBXBuildFile; productRef = B2DB4EA92A0E1B8500246CE8 /* VK */; };
 /* End PBXBuildFile section */
 
@@ -98,6 +101,9 @@
 		B2BA853529F3CDBA00F4B915 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2BA853629F3D01D00F4B915 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		B2BA853A29F3D91700F4B915 /* ThirdPartyAuthTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyAuthTitleView.swift; sourceTree = "<group>"; };
+		B2CE71C02A10C509006C42AB /* VKAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VKAuthProvider.swift; sourceTree = "<group>"; };
+		B2CE71C22A10C5C6006C42AB /* VKAuthConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VKAuthConfiguration.swift; sourceTree = "<group>"; };
+		B2CE71C42A10E704006C42AB /* VKAuthUserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VKAuthUserModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +201,7 @@
 			children = (
 				B254716B29F9979000E649CF /* Apple */,
 				B2C83D6529FD8F5C00301FE9 /* Google */,
+				B2CE71BF2A10C4F3006C42AB /* VK */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -372,6 +379,16 @@
 				B215B14C29FFC9D800F59065 /* GoogleAuthUserModel.swift */,
 			);
 			path = Google;
+			sourceTree = "<group>";
+		};
+		B2CE71BF2A10C4F3006C42AB /* VK */ = {
+			isa = PBXGroup;
+			children = (
+				B2CE71C22A10C5C6006C42AB /* VKAuthConfiguration.swift */,
+				B2CE71C02A10C509006C42AB /* VKAuthProvider.swift */,
+				B2CE71C42A10E704006C42AB /* VKAuthUserModel.swift */,
+			);
+			path = VK;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -628,12 +645,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2CE71C52A10E704006C42AB /* VKAuthUserModel.swift in Sources */,
 				B215B15029FFD52400F59065 /* UIApplication.swift in Sources */,
 				B2027FEE2A0A4F4C0036D9A0 /* ThirdPartyAuthServiceInterface.swift in Sources */,
 				B215B14D29FFC9D800F59065 /* GoogleAuthUserModel.swift in Sources */,
 				B285D5E929F2D02600B86937 /* BaseAuthProvider.swift in Sources */,
+				B2CE71C12A10C509006C42AB /* VKAuthProvider.swift in Sources */,
 				B285D5E329F2CFF300B86937 /* ThirdPartyAuthUserModel.swift in Sources */,
 				B285D5E129F2CFEA00B86937 /* ThirdPartyAuthType.swift in Sources */,
+				B2CE71C32A10C5C6006C42AB /* VKAuthConfiguration.swift in Sources */,
 				B254716429F97D6600E649CF /* UserDataModel.swift in Sources */,
 				B215B14529FFA92200F59065 /* GoogleAuthProvider.swift in Sources */,
 				B2027FEA2A0A4DF90036D9A0 /* ThirdPartyAuthService.swift in Sources */,

--- a/ThirdPartyAuth.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ThirdPartyAuth.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -35,6 +35,15 @@
         "revision" : "cee3c709307912d040bd1e06ca919875a92339c6",
         "version" : "2.0.0"
       }
+    },
+    {
+      "identity" : "vksdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/VKCOM/VKSDK-iOS",
+      "state" : {
+        "revision" : "bd6789232a6282ec50ce80571553f7ad973a765c",
+        "version" : "0.101.0"
+      }
     }
   ],
   "version" : 2


### PR DESCRIPTION
# Что сделано

- Добавлен модуль авторизации через VK ID
- Изменены методы авторизации у Google провайдера - общая логика получения токена вынесена в отдельную функцию
- Изменен метод signOut (добавлена дефолтная пустая реализация в BaseAuthProvider, т.к. AppleProvider этот метод не поддерживает) - добавлен closure, который вызовется после того, как пользователь будет разлогинен
- Обновлен ReadMe


[ReadMe с описанием](https://github.com/AdmiralBizon/ThirdPartyAuth/tree/add-vk-auth) 